### PR TITLE
mvp

### DIFF
--- a/include/pmerge/common/resource.hpp
+++ b/include/pmerge/common/resource.hpp
@@ -37,15 +37,15 @@ template <uint64_t IndexSize>
 IntermediateInteger PackFrom(uint64_t num, std::bitset<IndexSize> index) {
   static_assert(IndexSize <= 10, "index must be small");
   constexpr int64_t kMaxTakenBits = 1ll << (64 - IndexSize - 1);
-  int64_t taken_bits = num >> (IndexSize + 1);
-  assert(taken_bits >= 0 && ((IndexSize == 0) || taken_bits < kMaxTakenBits));
+  uint64_t taken_bits = (num >> (IndexSize + 1)) << IndexSize;
+  assert(taken_bits >= 0 && ((IndexSize == 0) || taken_bits < kMaxTakenBits) && taken_bits%(1<<IndexSize) == 0);
   constexpr uint64_t kMaxIndex = 1ull << IndexSize;
   assert(index.to_ullong() < kMaxIndex);
   assert((index.to_ullong() & (taken_bits << IndexSize)) == 0);
   IntermediateInteger intermediate =
       static_cast<IntermediateInteger>(index.to_ullong()) +
       std::numeric_limits<IntermediateInteger>::min() +
-      (taken_bits << IndexSize);
+      static_cast<IntermediateInteger>(taken_bits);
   assert(IsValid(intermediate));
   return intermediate;
 }

--- a/include/pmerge/common/vector_resource.hpp
+++ b/include/pmerge/common/vector_resource.hpp
@@ -8,10 +8,22 @@
 #include <immintrin.h>
 
 #include <bitset>
+#include <cstdint>
 #include <pmerge/common/resource.hpp>
 #include <vector>
 
 namespace pmerge::common {
+template <size_t IndexSize>
+std::vector<int64_t> FromDataAndIndex(const std::vector<uint64_t>& data,
+                                        std::bitset<IndexSize> index) {
+  std::vector<pmerge::IntermediateInteger> vec;
+  for (int64_t num : data) {
+    vec.push_back(pmerge::PackFrom(num, index));
+  }
+  return vec;
+}
+
+
 class VectorResource {
  public:
   explicit VectorResource(std::vector<pmerge::IntermediateInteger> vec);
@@ -21,15 +33,6 @@ class VectorResource {
   VectorResource(VectorResource&& other) noexcept = default;
   VectorResource& operator=(VectorResource&& other) noexcept = default;
 
-  template <size_t IndexSize>
-  static VectorResource FromDataAndIndex(const std::vector<uint64_t>& data,
-                                         std::bitset<IndexSize> index) {
-    std::vector<pmerge::IntermediateInteger> vec;
-    for (int64_t num : data) {
-      vec.push_back(pmerge::PackFrom(num, index));
-    }
-    return VectorResource{std::move(vec)};
-  }
 
   [[nodiscard]] int64_t Peek() const;
 

--- a/include/pmerge/two_way/simd_two_way.hpp
+++ b/include/pmerge/two_way/simd_two_way.hpp
@@ -17,9 +17,13 @@ template <pmerge::Resource FirstSource, pmerge::Resource SecondSource>
 class SimdTwoWayMerger {
  public:
   using ValueType = __m256i;
-  SimdTwoWayMerger(FirstSource first, SecondSource second) noexcept
-      : first_(std::forward<FirstSource>(first)),
-        second_(std::forward<SecondSource>(second)) {
+  SimdTwoWayMerger(FirstSource first, SecondSource second) noexcept: SimdTwoWayMerger(std::move(first), std::move(second), true){}
+  SimdTwoWayMerger(FirstSource first, SecondSource second, bool print_registers) noexcept
+      : print_registers_(print_registers),
+        first_(std::forward<FirstSource>(first)),
+        second_(std::forward<SecondSource>(second)),
+        vMin_(pmerge::simd::kInfVector),
+        vMax_(pmerge::simd::kInfVector) {
     static_assert(pmerge::Resource<SimdTwoWayMerger>,
                   "SimdTwoWayMerger must be pmerge::Resource");
     vMin_ = first_.GetOne();
@@ -53,10 +57,15 @@ class SimdTwoWayMerger {
   void PrintRegister(
       std::string_view prefix = "",
       std::source_location loc = std::source_location::current()) const {
-    std::cout << std::format(
-        "state: {},  min: {}, max: {}, header line number: {}\n", prefix,
-        simd::ToString(vMin_), simd::ToString(vMax_), loc.line());
+#ifndef NDEBUG
+    if (print_registers_){
+      std::cout << std::format(
+          "state: {},  min: {}, max: {}, header line number: {}\n", prefix,
+          simd::ToString(vMin_), simd::ToString(vMax_), loc.line());
+      }
+#endif
   }
+  bool print_registers_;
   FirstSource first_;
   SecondSource second_;
   ValueType vMin_;

--- a/pmerge/tests/simd_two_way_vector_resource_test.cpp
+++ b/pmerge/tests/simd_two_way_vector_resource_test.cpp
@@ -4,47 +4,77 @@
 #include <gtest/gtest.h>
 
 #include <algorithm>
+#include <bitset>
 #include <pmerge/common/vector_resource.hpp>
 #include <pmerge/simd/utils.hpp>
 #include <pmerge/two_way/simd_two_way.hpp>
 #include <random>
 
+#include <pmerge/common/assert.hpp>
+#include <pmerge/common/resource.hpp>
 #include "utils.hpp"
 
+static constexpr auto kFirstIdentifier = std::bitset<1>(0);
+
+static constexpr auto kSecondIdentifier = std::bitset<1>(1);
+
+using pmerge::common::FromDataAndIndex;
+
 void TestMerge(const std::vector<int64_t>& first_vec,
-               const std::vector<int64_t>& second_vec) {
-  pmerge::common::VectorResource res1(first_vec);
-  std::vector<uint64_t> merged;
+               const std::vector<int64_t>& second_vec, bool print_registers) {
+
+  
+  std::vector<int64_t> merged;
   std::ranges::merge(first_vec, second_vec, std::back_inserter(merged));
-  pmerge::common::VectorResource res2(second_vec);
-  pmerge::two_way::SimdTwoWayMerger merger{std::move(res1), std::move(res2)};
+  auto compare_and_push = [&, first_idx=0, second_idx=0] (std::bitset<1> index) mutable{
+    if (index.to_ullong() == 0){
+      EXPECT_EQ(merged[first_idx+second_idx], first_vec[first_idx]) << std::format("total_idx: {}, first_idx: {}", first_idx+second_idx, first_idx);
+      ++first_idx;
+    }else{
+      EXPECT_EQ(merged[first_idx+second_idx], second_vec[second_idx])<< std::format("total_idx: {}, second_idx: {}", first_idx+second_idx, second_idx);
+      ++second_idx;
+    }
+  };
+  pmerge::common::VectorResource res1{first_vec};
+  pmerge::common::VectorResource res2{second_vec}; 
+  pmerge::two_way::SimdTwoWayMerger merger{std::move(res1), std::move(res2), print_registers};
+  if (merged.size() < 100){
+    for(auto num: merged){
+      std::cout << pmerge::MakeReadableString(num) << ' ';
+    }
+    std::cout << std::endl;
+  }
   static_assert(pmerge::Resource<decltype(merger)>, "asd");
-
-  ASSERT_EQ(merger.Peek(), merged.front());
-
-  for (int idx = 0; idx + 4 <= std::ssize(merged); idx += 4) {
+  for (int idx = 0; idx + 4 <= std::ssize(merged); idx += 4) { 
     auto reg = merger.GetOne();
     auto arr = pmerge::simd::AsArray(reg);
-    ASSERT_EQ(arr[0], merged[idx + 0]) << idx + 0;
-    ASSERT_EQ(arr[1], merged[idx + 1]) << idx + 1;
-    ASSERT_EQ(arr[2], merged[idx + 2]) << idx + 2;
-    ASSERT_EQ(arr[3], merged[idx + 3]) << idx + 3;
+    compare_and_push(*pmerge::ExtractIdentifer<1>(arr[0]));
+    compare_and_push(*pmerge::ExtractIdentifer<1>(arr[1]));
+    compare_and_push(*pmerge::ExtractIdentifer<1>(arr[2]));
+    compare_and_push(*pmerge::ExtractIdentifer<1>(arr[3]));
   }
+  auto last_arr = pmerge::simd::AsArray(merger.GetOne());
+  int last_arr_idx = 0;
+  while (last_arr_idx != 4 && last_arr[last_arr_idx] != pmerge::kInf ){
+      compare_and_push(*pmerge::ExtractIdentifer<1>(last_arr[last_arr_idx]));
+      last_arr_idx++;
+  }
+  ASSERT_EQ(merger.Peek(), pmerge::kInf) << "not all values from merger checked";
 }
 
 TEST(Merge, Simple) {
-  TestMerge(std::vector<int64_t>({1, 7, 9, 11, 32}),
-            std::vector<int64_t>({2, 3, 4, 5, 32}));
+  TestMerge(FromDataAndIndex(std::vector<uint64_t>({1, 7, 9, 11, 32}), kFirstIdentifier),
+            FromDataAndIndex(std::vector<uint64_t>({2, 3, 4, 5, 32}), kSecondIdentifier), true);
 }
 
 TEST(Merge, Random) {
   std::mt19937 random(123);
-  std::vector<int64_t> first, second;
+  std::vector<uint64_t> first, second;
   first.resize(1000);
   second.resize(1000);
   for (int _ = 0; _ < 1000; ++_) {
     FillVector(first, random);
     FillVector(second, random);
-    TestMerge(first, second);
+    TestMerge(FromDataAndIndex(first, kFirstIdentifier), FromDataAndIndex(second, kSecondIdentifier), false);
   }
 }

--- a/pmerge/tests/utils.hpp
+++ b/pmerge/tests/utils.hpp
@@ -7,6 +7,7 @@
 
 #include <immintrin.h>
 
+#include <cstdint>
 #include <ostream>
 #include <random>
 #include <vector>
@@ -65,8 +66,8 @@ inline std::array<uint64_t, 8> MergeSimple(__m256i first, __m256i second) {
   return ret;
 }
 
-inline void FillVector(std::vector<int64_t>& vec, std::mt19937& random) {
-  int current = 0;
+inline void FillVector(std::vector<uint64_t>& vec, std::mt19937& random) {
+  uint64_t current = 0;
   std::uniform_int_distribution<> distr(0, 10);
   for (auto& num : vec) {
     num = current += distr(random);


### PR DESCRIPTION
added print_registers_ variable because terminal output was the bottleneck for test completion

also moved packing to IntermediateInteger for simplicity